### PR TITLE
Minor cleanup

### DIFF
--- a/cogetserverpid.h
+++ b/cogetserverpid.h
@@ -23,7 +23,6 @@ typedef struct tagCOGETSERVERPID_OBJREFHDR
 inline HRESULT CoGetServerPID(IUnknown* punk, DWORD* pdwPID)
 {
   HRESULT hr;
-  COGETSERVERPID_OBJREFHDR *pObjRefHdr = NULL;
 
   if(pdwPID == NULL) return E_POINTER;
   if(punk == NULL) return E_INVALIDARG;
@@ -53,7 +52,7 @@ inline HRESULT CoGetServerPID(IUnknown* punk, DWORD* pdwPID)
         /* Start out pessimistic. */
         hr = RPC_E_INVALID_OBJREF;
 
-        pObjRefHdr = (COGETSERVERPID_OBJREFHDR*)GlobalLock(hg);
+        COGETSERVERPID_OBJREFHDR *pObjRefHdr = (COGETSERVERPID_OBJREFHDR*)GlobalLock(hg);
         if(pObjRefHdr != NULL)
         {
           /* Verify that the signature is MEOW. */

--- a/cogetserverpid.h
+++ b/cogetserverpid.h
@@ -22,8 +22,6 @@ typedef struct tagCOGETSERVERPID_OBJREFHDR
 
 inline HRESULT CoGetServerPID(IUnknown* punk, DWORD* pdwPID)
 {
-  HRESULT hr;
-
   if(pdwPID == NULL) return E_POINTER;
   if(punk == NULL) return E_INVALIDARG;
 
@@ -31,13 +29,13 @@ inline HRESULT CoGetServerPID(IUnknown* punk, DWORD* pdwPID)
       /* Make sure this is a standard proxy, otherwise we can't make any
          assumptions about OBJREF wire format. */
       CComPtr<IUnknown> pProxyManager;
-      hr = punk->QueryInterface(IID_IProxyManager, (void**)&pProxyManager);
+      HRESULT hr = punk->QueryInterface(IID_IProxyManager, (void**)&pProxyManager);
       if(FAILED(hr)) return hr;
   }
 
   /* Marshal the interface to get a new OBJREF. */
   CComPtr<IStream> pMarshalStream;
-  hr = ::CreateStreamOnHGlobal(NULL, TRUE, &pMarshalStream);
+  HRESULT hr = ::CreateStreamOnHGlobal(NULL, TRUE, &pMarshalStream);
   if(SUCCEEDED(hr))
   {
     hr = ::CoMarshalInterface(pMarshalStream, IID_IUnknown, punk, 

--- a/cogetserverpid.h
+++ b/cogetserverpid.h
@@ -23,7 +23,6 @@ typedef struct tagCOGETSERVERPID_OBJREFHDR
 inline HRESULT CoGetServerPID(IUnknown* punk, DWORD* pdwPID)
 {
   HRESULT hr;
-  HGLOBAL hg = NULL;
   COGETSERVERPID_OBJREFHDR *pObjRefHdr = NULL;
 
   if(pdwPID == NULL) return E_POINTER;
@@ -47,6 +46,7 @@ inline HRESULT CoGetServerPID(IUnknown* punk, DWORD* pdwPID)
     if(SUCCEEDED(hr))
     {
       /* We just created the stream so it's safe to go back to a raw pointer. */
+      HGLOBAL hg = NULL;
       hr = ::GetHGlobalFromStream(pMarshalStream, &hg);
       if(SUCCEEDED(hr))
       {

--- a/cogetserverpid.h
+++ b/cogetserverpid.h
@@ -23,7 +23,6 @@ typedef struct tagCOGETSERVERPID_OBJREFHDR
 inline HRESULT CoGetServerPID(IUnknown* punk, DWORD* pdwPID)
 {
   HRESULT hr;
-  IUnknown* pProxyManager = NULL;
   HGLOBAL hg = NULL;
   COGETSERVERPID_OBJREFHDR *pObjRefHdr = NULL;
   LARGE_INTEGER zero = {0};
@@ -31,12 +30,13 @@ inline HRESULT CoGetServerPID(IUnknown* punk, DWORD* pdwPID)
   if(pdwPID == NULL) return E_POINTER;
   if(punk == NULL) return E_INVALIDARG;
 
-  /* Make sure this is a standard proxy, otherwise we can't make any
-     assumptions about OBJREF wire format. */
-  hr = punk->QueryInterface(IID_IProxyManager, (void**)&pProxyManager);
-  if(FAILED(hr)) return hr;
-  
-  pProxyManager->Release();
+  {
+      /* Make sure this is a standard proxy, otherwise we can't make any
+         assumptions about OBJREF wire format. */
+      CComPtr<IUnknown> pProxyManager;
+      hr = punk->QueryInterface(IID_IProxyManager, (void**)&pProxyManager);
+      if(FAILED(hr)) return hr;
+  }
 
   /* Marshal the interface to get a new OBJREF. */
   CComPtr<IStream> pMarshalStream;

--- a/cogetserverpid.h
+++ b/cogetserverpid.h
@@ -5,8 +5,7 @@ All rights reserved.
 Released under the Modified BSD license. For details, please see LICENSE file.
 
 *******************************************************************************/
-#ifndef INCLUDED_COGETSERVERPID_H__
-#define INCLUDED_COGETSERVERPID_H__
+#pragma once
 
 #include <objbase.h>
 
@@ -80,5 +79,3 @@ inline HRESULT CoGetServerPID(IUnknown* punk, DWORD* pdwPID)
 
   return hr;
 }
-
-#endif // INCLUDED_COGETSERVERPID_H__

--- a/cogetserverpid.h
+++ b/cogetserverpid.h
@@ -7,7 +7,7 @@ Released under the Modified BSD license. For details, please see LICENSE file.
 *******************************************************************************/
 #pragma once
 
-#include <objbase.h>
+#include <atlbase.h>
 
 /* This structure represents the OBJREF up to the PID at offset 52 bytes.
    1-byte structure packing to make sure offsets are deterministic. */
@@ -24,7 +24,6 @@ inline HRESULT CoGetServerPID(IUnknown* punk, DWORD* pdwPID)
 {
   HRESULT hr;
   IUnknown* pProxyManager = NULL;
-  IStream* pMarshalStream = NULL;
   HGLOBAL hg = NULL;
   COGETSERVERPID_OBJREFHDR *pObjRefHdr = NULL;
   LARGE_INTEGER zero = {0};
@@ -40,6 +39,7 @@ inline HRESULT CoGetServerPID(IUnknown* punk, DWORD* pdwPID)
   pProxyManager->Release();
 
   /* Marshal the interface to get a new OBJREF. */
+  CComPtr<IStream> pMarshalStream;
   hr = ::CreateStreamOnHGlobal(NULL, TRUE, &pMarshalStream);
   if(SUCCEEDED(hr))
   {
@@ -73,8 +73,6 @@ inline HRESULT CoGetServerPID(IUnknown* punk, DWORD* pdwPID)
       pMarshalStream->Seek(zero, SEEK_SET, NULL);
       CoReleaseMarshalData(pMarshalStream);
     }
-
-    pMarshalStream->Release();
   }
 
   return hr;

--- a/cogetserverpid.h
+++ b/cogetserverpid.h
@@ -25,7 +25,6 @@ inline HRESULT CoGetServerPID(IUnknown* punk, DWORD* pdwPID)
   HRESULT hr;
   HGLOBAL hg = NULL;
   COGETSERVERPID_OBJREFHDR *pObjRefHdr = NULL;
-  LARGE_INTEGER zero = {0};
 
   if(pdwPID == NULL) return E_POINTER;
   if(punk == NULL) return E_INVALIDARG;
@@ -70,6 +69,7 @@ inline HRESULT CoGetServerPID(IUnknown* punk, DWORD* pdwPID)
       }
 
       /* Rewind stream and release marshal data to keep refcount in order. */
+      LARGE_INTEGER zero = {0};
       pMarshalStream->Seek(zero, SEEK_SET, NULL);
       CoReleaseMarshalData(pMarshalStream);
     }


### PR DESCRIPTION
Some minor non-functional changes to simplify the implementation:
* Replace include guard with `#pragma once` (supported since VS 2003).
* Introduce RAII for COM object lifetime management.
* Postpone variable declaration until actual usage.
* Early returns where possible to flatten out indentation.